### PR TITLE
Support 6to5-source 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ rvm:
 
 gemfile:
   - test/gemfiles/1.14
+  - test/gemfiles/2.13

--- a/6to5.gemspec
+++ b/6to5.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     'LICENSE'
   ]
 
-  s.add_dependency '6to5-source', '~> 1.14'
+  s.add_dependency '6to5-source', '>= 1.14', '< 3'
   s.add_dependency 'execjs', '~> 2.0'
 
   s.authors = ['Joshua Peek']

--- a/test/gemfiles/2.13
+++ b/test/gemfiles/2.13
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem '6to5-source', '~> 2.13.0'
+gem 'execjs'
+gem 'rake'
+gem 'minitest'


### PR DESCRIPTION
Released gem with `s.add_dependency '6to5-source', '~> 1.14'`
doesn't allow using '6to5-source' 2.x .